### PR TITLE
check for polyglossia alongside babel

### DIFF
--- a/source/svg.dtx
+++ b/source/svg.dtx
@@ -1985,11 +1985,15 @@ svg-extract -- Extract independent graphic files from SVG pictures
 %
 % \begin{macro}{\svg@deactivate@dq}
 % \changes{v2.02}{2018/09/07}{new}^^A
-% In order to avoid errors concerning file names with package \pkg{babel} and 
-% it's active double quotes, this command is defined. 
+% In order to avoid errors concerning file names with packages
+% \pkg{babel} and \pkg{polyglossia} and active double quotes, this
+% command is defined.
 %    \begin{macrocode}
 \newcommand*\svg@deactivate@dq{}
 \AfterPackage*{babel}{%
+  \renewcommand*\svg@deactivate@dq{\bbl@deactivate{"}}%
+}
+\AfterPackage*{polyglossia}{%
   \renewcommand*\svg@deactivate@dq{\bbl@deactivate{"}}%
 }
 %    \end{macrocode}


### PR DESCRIPTION
This is in relation to file names and active double quotes.

svg produces an `Undefined control sequence` error when using xelatex and polyglossia (i.e. not babel).

This patch adds support for polyglossia alongside babel. However, the fix only works for languages that support babel shorthands, because only those languages load `babelsh.def`, in which `\bbl@deactivate` is defined.

``` latex
\documentclass{article}

\usepackage{svg}

\usepackage{polyglossia}
% Languages that load babelsh.def (e.g. Dutch) work because 
% \bbl@deactivate is defined in that file.
\setmainlanguage[babelshorthands]{dutch}

% Other languages that do not load babelsh.def (e.g. English)
% still result in \bbl@deactivate undefined.
% \setmainlanguage[babelshorthands]{english}

\begin{document}
\includesvg{./figure.svg}
\end{document}
```

```
ERROR: Undefined control sequence.

--- TeX said ---
\svg@deactivate@dq ->\bbl@deactivate 
                                     {"}
l.595 }
```

