### PR TITLE
Fix `Runaway argument' for macOS 10.15

### DIFF
--- a/source/svg.dtx
+++ b/source/svg.dtx
@@ -3477,7 +3477,7 @@ svg-extract -- Extract independent graphic files from SVG pictures
 % found error message to the user.
 %    \begin{macrocode}
     \edef\svg@tempa{%
-      \edef\noexpand\svg@tempa{\noexpand\@@input|"'\svg@ink@exe' -V 2>&1" }%
+      \edef\noexpand\svg@tempa{\noexpand\@@input|"'\svg@ink@exe'\space-V" }%
     }%
     \svg@tempa%
     \trim@spaces@in\svg@tempa%

--- a/source/svg.dtx
+++ b/source/svg.dtx
@@ -3477,7 +3477,7 @@ svg-extract -- Extract independent graphic files from SVG pictures
 % found error message to the user.
 %    \begin{macrocode}
     \edef\svg@tempa{%
-      \edef\noexpand\svg@tempa{\noexpand\@@input|"'\svg@ink@exe'\space-V" }%
+      \edef\noexpand\svg@tempa{\noexpand\@@input|"LC_ALL=C LANG=C '\svg@ink@exe' -V 2>&1" }%
     }%
     \svg@tempa%
     \trim@spaces@in\svg@tempa%


### PR DESCRIPTION
when verifying version of inkscape:

    (|'inkscape' -V 2>&1)
    Runaway argument?
    ! Paragraph ended before \svg@tempb was complete.
    <to be read again>
                       \par
    l.11 \begin{document}

    ?

Reverts partially 9b9c5554d5e4a554c9f338ca726dc0df62d41c3c
(which fixes  mrpiggi#31)